### PR TITLE
Kube ResourceLoader using ConfigsetService's cache

### DIFF
--- a/solr/modules/kubernetes/src/java/org/apache/solr/cloud/kube/KubernetesConfigSetService.java
+++ b/solr/modules/kubernetes/src/java/org/apache/solr/cloud/kube/KubernetesConfigSetService.java
@@ -211,7 +211,15 @@ public class KubernetesConfigSetService extends ConfigSetService {
     String configSetName = cd.getConfigSet();
 
     return new KubernetesSolrResourceLoader(
-        cd.getInstanceDir(), configSetName, parentLoader.getClassLoader(), coreV1Api);
+        cd.getInstanceDir(),
+        configSetName,
+        parentLoader.getClassLoader(),
+        existingConfigSetConfigMaps);
+  }
+
+  /** Package-private: returns the live ConfigMap cache kept up to date by the informer. */
+  Map<String, V1ConfigMap> getConfigMapCache() {
+    return existingConfigSetConfigMaps;
   }
 
   @Override

--- a/solr/modules/kubernetes/src/java/org/apache/solr/cloud/kube/KubernetesSolrResourceLoader.java
+++ b/solr/modules/kubernetes/src/java/org/apache/solr/cloud/kube/KubernetesSolrResourceLoader.java
@@ -16,20 +16,15 @@
  */
 package org.apache.solr.cloud.kube;
 
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Locale;
+import java.util.Map;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.core.SolrResourceNotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * ResourceLoader that works with Kubernetes ConfigMaps.
@@ -37,87 +32,53 @@ import org.slf4j.LoggerFactory;
  * <p>This loader attempts to load resources from a Kubernetes ConfigMap corresponding to the
  * configured configSet. If a resource is not found in the ConfigMap, it falls back to the classpath
  * loader.
+ *
+ * <p>Resources are served from the live ConfigMap cache maintained by {@link
+ * KubernetesConfigSetService}. The cache is kept up to date by a Kubernetes informer, so every call
+ * to {@link #openResource(String)} reflects the current state of the ConfigMap without making an
+ * API round-trip.
  */
 public class KubernetesSolrResourceLoader extends SolrResourceLoader {
 
   private final String configSetName;
-  private final String namespace;
-  private final CoreV1Api coreV1Api;
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final Map<String, V1ConfigMap> configMapCache;
 
   /**
    * Creates a new KubernetesSolrResourceLoader.
    *
-   * <p>This loader will first attempt to load resources from a Kubernetes ConfigMap for the given
-   * configSet. If not found, it will delegate to the context classloader.
+   * <p>This loader will first attempt to load resources from the provided ConfigMap cache. If not
+   * found, it will delegate to the context classloader.
    *
    * @param instanceDir the instance directory for the core
-   * @param configSetName the name of the configSet (used to look up the ConfigMap)
+   * @param configSetName the name of the configSet (used to look up the ConfigMap in the cache)
    * @param parent the parent classloader
-   * @param coreV1Api the Kubernetes CoreV1Api client
+   * @param configMapCache the live ConfigMap cache (keyed by configSet name), kept up to date by
+   *     the Kubernetes informer in {@link KubernetesConfigSetService}
    */
   public KubernetesSolrResourceLoader(
-      Path instanceDir, String configSetName, ClassLoader parent, CoreV1Api coreV1Api) {
+      Path instanceDir,
+      String configSetName,
+      ClassLoader parent,
+      Map<String, V1ConfigMap> configMapCache) {
     super(instanceDir, parent);
     this.configSetName = configSetName;
-    this.coreV1Api = coreV1Api;
-    this.namespace = System.getenv(KubernetesConfigSetService.POD_NAMESPACE_ENV_VAR);
+    this.configMapCache = configMapCache;
   }
 
   /**
-   * Opens any resource by its name. First attempts to load the resource from the Kubernetes
+   * Opens any resource by its name. First attempts to load the resource from the cached Kubernetes
    * ConfigMap for the configSet. If not found, delegates to the parent classloader.
    *
    * @return the stream for the named resource
    */
   @Override
   public InputStream openResource(String resource) throws IOException {
-    // Try to get the resource from the Kubernetes ConfigMap
-    try {
-      // TODO: Cache the ConfigMap locally rather than fetching from the API each time.
-      // Consider passing in the existingConfigSetConfigMaps cache from KubernetesConfigSetService.
-      String solrCloudName = System.getenv(KubernetesConfigSetService.SOLR_CLOUD_NAME_ENV_VAR);
-      String labelSelector =
-          String.format(
-              Locale.ROOT,
-              "%s=%s",
-              String.format(
-                  Locale.ROOT, KubernetesConfigSetService.CONFIG_SET_LABEL_KEY, solrCloudName),
-              KubernetesConfigSetService.CONFIG_SET_LABEL_VALUE);
-
-      V1ConfigMap configMap =
-          coreV1Api
-              .listNamespacedConfigMap(namespace)
-              .labelSelector(labelSelector)
-              .execute()
-              .getItems()
-              .stream()
-              .filter(
-                  cm -> {
-                    if (cm.getMetadata() == null || cm.getMetadata().getAnnotations() == null) {
-                      return false;
-                    }
-                    return configSetName.equals(
-                        cm.getMetadata()
-                            .getAnnotations()
-                            .get(KubernetesConfigSetService.CONFIG_SET_NAME_ANNOTATION_KEY));
-                  })
-              .findFirst()
-              .orElse(null);
-
-      if (configMap != null && configMap.getData() != null) {
-        String data = configMap.getData().get(resource);
-        if (data != null) {
-          return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
-        }
+    V1ConfigMap configMap = configMapCache.get(configSetName);
+    if (configMap != null && configMap.getData() != null) {
+      String data = configMap.getData().get(resource);
+      if (data != null) {
+        return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
       }
-    } catch (ApiException e) {
-      log.warn(
-          "Could not retrieve resource '{}' from Kubernetes ConfigMap for configSet '{}'",
-          resource,
-          configSetName,
-          e);
     }
 
     // Fall back to the classpath loader

--- a/solr/modules/kubernetes/src/test/org/apache/solr/cloud/kube/KubernetesConfigSetServiceTest.java
+++ b/solr/modules/kubernetes/src/test/org/apache/solr/cloud/kube/KubernetesConfigSetServiceTest.java
@@ -362,7 +362,7 @@ public class KubernetesConfigSetServiceTest extends SolrTestCase {
     when(cd.getConfigSet()).thenReturn("my-configset");
     when(cd.getInstanceDir()).thenReturn(createTempDir());
 
-    org.apache.solr.core.SolrResourceLoader loader = service.createCoreResourceLoader(cd);
+    SolrResourceLoader loader = service.createCoreResourceLoader(cd);
     assertTrue(loader instanceof KubernetesSolrResourceLoader);
     assertEquals("my-configset", ((KubernetesSolrResourceLoader) loader).getConfigSetName());
   }

--- a/solr/modules/kubernetes/src/test/org/apache/solr/cloud/kube/KubernetesSolrResourceLoaderTest.java
+++ b/solr/modules/kubernetes/src/test/org/apache/solr/cloud/kube/KubernetesSolrResourceLoaderTest.java
@@ -16,31 +16,16 @@
  */
 package org.apache.solr.cloud.kube;
 
-import static org.apache.solr.SolrTestCaseJ4.assumeWorkingMockito;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
 import org.apache.solr.SolrTestCase;
 import org.apache.solr.core.SolrResourceNotFoundException;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class KubernetesSolrResourceLoaderTest extends SolrTestCase {
-
-  @BeforeClass
-  public static void setUpClass() {
-    assumeWorkingMockito();
-  }
 
   private V1ConfigMap makeConfigMap(String configSetName, Map<String, String> data) {
     V1ObjectMeta meta =
@@ -50,24 +35,22 @@ public class KubernetesSolrResourceLoaderTest extends SolrTestCase {
     return new V1ConfigMap().metadata(meta).data(data);
   }
 
-  private KubernetesSolrResourceLoader makeLoader(CoreV1Api api, String configSetName) {
+  private KubernetesSolrResourceLoader makeLoader(
+      Map<String, V1ConfigMap> cache, String configSetName) {
     return new KubernetesSolrResourceLoader(
         createTempDir(),
         configSetName,
         KubernetesSolrResourceLoaderTest.class.getClassLoader(),
-        api);
+        cache);
   }
 
   @Test
   public void testOpenResourceFromConfigMap() throws Exception {
-    CoreV1Api api = mock(CoreV1Api.class, RETURNS_DEEP_STUBS);
     String resource = "solrconfig.xml";
     String content = "<config/>";
     V1ConfigMap cm = makeConfigMap("my-configset", Map.of(resource, content));
-    when(api.listNamespacedConfigMap(any()).labelSelector(any()).execute().getItems())
-        .thenReturn(List.of(cm));
 
-    KubernetesSolrResourceLoader loader = makeLoader(api, "my-configset");
+    KubernetesSolrResourceLoader loader = makeLoader(Map.of("my-configset", cm), "my-configset");
     try (InputStream is = loader.openResource(resource)) {
       String result = new String(is.readAllBytes(), StandardCharsets.UTF_8);
       assertEquals(content, result);
@@ -76,13 +59,10 @@ public class KubernetesSolrResourceLoaderTest extends SolrTestCase {
 
   @Test
   public void testOpenResourceFallbackToClasspath() throws Exception {
-    CoreV1Api api = mock(CoreV1Api.class, RETURNS_DEEP_STUBS);
     // ConfigMap exists but does not contain the requested resource
     V1ConfigMap cm = makeConfigMap("my-configset", Map.of("other-file.xml", "data"));
-    when(api.listNamespacedConfigMap(any()).labelSelector(any()).execute().getItems())
-        .thenReturn(List.of(cm));
 
-    KubernetesSolrResourceLoader loader = makeLoader(api, "my-configset");
+    KubernetesSolrResourceLoader loader = makeLoader(Map.of("my-configset", cm), "my-configset");
     try (InputStream is = loader.openResource("test-classpath-resource.txt")) {
       assertNotNull(is);
       String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
@@ -92,37 +72,17 @@ public class KubernetesSolrResourceLoaderTest extends SolrTestCase {
 
   @Test
   public void testOpenResourceNotFoundAnywhere() throws Exception {
-    CoreV1Api api = mock(CoreV1Api.class, RETURNS_DEEP_STUBS);
-    when(api.listNamespacedConfigMap(any()).labelSelector(any()).execute().getItems())
-        .thenReturn(List.of());
-
-    KubernetesSolrResourceLoader loader = makeLoader(api, "my-configset");
+    // configSet not in cache, resource not on classpath
+    KubernetesSolrResourceLoader loader = makeLoader(Map.of(), "my-configset");
     assertThrows(
         SolrResourceNotFoundException.class,
         () -> loader.openResource("absolutely-nonexistent-resource.xml"));
   }
 
   @Test
-  public void testApiExceptionFallsBackToClasspath() throws Exception {
-    CoreV1Api api = mock(CoreV1Api.class, RETURNS_DEEP_STUBS);
-    when(api.listNamespacedConfigMap(any()).labelSelector(any()).execute())
-        .thenThrow(new ApiException("simulated Kubernetes API failure"));
-
-    KubernetesSolrResourceLoader loader = makeLoader(api, "my-configset");
-    try (InputStream is = loader.openResource("test-classpath-resource.txt")) {
-      assertNotNull(is);
-    }
-  }
-
-  @Test
-  public void testConfigMapAnnotationMismatchFallsBackToClasspath() throws Exception {
-    CoreV1Api api = mock(CoreV1Api.class, RETURNS_DEEP_STUBS);
-    // ConfigMap has annotation for a different configSet, so filter does not match
-    V1ConfigMap cm = makeConfigMap("other-configset", Map.of("solrconfig.xml", "<config/>"));
-    when(api.listNamespacedConfigMap(any()).labelSelector(any()).execute().getItems())
-        .thenReturn(List.of(cm));
-
-    KubernetesSolrResourceLoader loader = makeLoader(api, "my-configset");
+  public void testConfigSetNotInCache_fallsBackToClasspath() throws Exception {
+    // configSet absent from cache → fall through to classpath
+    KubernetesSolrResourceLoader loader = makeLoader(Map.of(), "my-configset");
     try (InputStream is = loader.openResource("test-classpath-resource.txt")) {
       assertNotNull(is);
     }
@@ -130,8 +90,7 @@ public class KubernetesSolrResourceLoaderTest extends SolrTestCase {
 
   @Test
   public void testGetConfigSetName() {
-    CoreV1Api api = mock(CoreV1Api.class, RETURNS_DEEP_STUBS);
-    KubernetesSolrResourceLoader loader = makeLoader(api, "test-configset");
+    KubernetesSolrResourceLoader loader = makeLoader(Map.of(), "test-configset");
     assertEquals("test-configset", loader.getConfigSetName());
   }
 }


### PR DESCRIPTION
This was the idea of Claude Code.

`KubernetesSolrResourceLoader` does not need to talk to k8s itself, instead it can lookup `KubernetesConfigSetService`s cached map which is live updated. 

I was initially sceptical, but realize that the only user of these resourceLoaders are actually the Cores for loading configset. `CoreContainer` uses the plain `SolrResourceLoader` for its business.

This solves the TODO about caching ConfigMap.

WDYT?